### PR TITLE
Add CA certificate readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following environment variables need to be set:
 For `vault` itself:
 
     VAULT_ADDR - this is an address to your vault server
+    VAULT_CACERT - if you have a self issued certificate, point this environment variable to the location of the root CA file
 
 For `secrets_cli`:
 


### PR DESCRIPTION
This is cool info so you don't need to calm through endless Vault documentation. Don't know where to put it though.