### PR TITLE
FIX undefined method policies for nil class

### DIFF
--- a/lib/secrets_cli/vault/auth.rb
+++ b/lib/secrets_cli/vault/auth.rb
@@ -21,16 +21,18 @@ module SecretsCli
       def command
         case auth_method
         when 'github'
-          ::Vault.auth.github(auth_token)
+          secret = ::Vault.auth.github(auth_token)
         when 'token'
-          ::Vault.auth.token(auth_token)
+          secret = ::Vault.auth.token(auth_token)
         when 'app_id'
-          ::Vault.auth.app_id(auth_app_id, auth_user_id)
+          secret = ::Vault.auth.app_id(auth_app_id, auth_user_id)
         when 'approle'
-          ::Vault.auth.approle(auth_role_id, auth_secret_id)
+          secret = ::Vault.auth.approle(auth_role_id, auth_secret_id)
         else
           error! "Unknown auth method #{auth_method}"
-        end.auth.policies
+        end
+
+        secret.auth&.policy || secret.data[:policies]
       end
     end
   end


### PR DESCRIPTION
When using the `secrets pull` command, I get an `undefined method 'policies' for nil:NilClass` error.

Replacing `.auth.policies` by `.data[:policies]` fixed this issue.