### PR TITLE
Add ci_mode to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ To pull from a different environment, also supply the `-e` flag and the `-f` fla
 
     $ secrets pull -e production -f config/application.production.yml
 
-You can also supply the `-ci_mode` or `-y` flag to disable prompts and outputs.
+You can also supply the `--ci_mode` or `-y` flag to disable prompts and outputs.
 
 ### Push
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ To pull from a different environment, also supply the `-e` flag and the `-f` fla
 
     $ secrets pull -e production -f config/application.production.yml
 
+You can also supply the `-ci_mode` or `-y` flag to disable prompts and outputs.
+
 ### Push
 
     $ secrets push


### PR DESCRIPTION
I see many people hack this via '> /dev/null', so would be useful to have it in readme.