### PR TITLE
fix token method authentication

### DIFF
--- a/lib/secrets_cli/vault/auth.rb
+++ b/lib/secrets_cli/vault/auth.rb
@@ -23,14 +23,14 @@ module SecretsCli
         when 'github'
           vault.auth.github(auth_token)
         when 'token'
-          vault.auth.token(auth_token)
+          return auth_token
         when 'app_id'
           vault.auth.app_id(auth_app_id, auth_user_id)
         when 'approle'
           vault.auth.approle(auth_role_id, auth_secret_id)
         else
           error! "Unknown auth method #{auth_method}"
-        end.auth
+        end.auth.client_token
       end
 
       def vault

--- a/lib/secrets_cli/vault/base.rb
+++ b/lib/secrets_cli/vault/base.rb
@@ -26,7 +26,7 @@ module SecretsCli
         @vault ||=
           ::Vault::Client.new(
             address: config.vault_addr,
-            token: SecretsCli::Vault::Auth.new(options).call.client_token
+            token: SecretsCli::Vault::Auth.new(options).call
           )
       end
 


### PR DESCRIPTION
Using the token validation method did not work, and returns a 
```
undefined method `client_token' for nil
```
error when trying to use it.

This PR fixes the token auth method.
The `feature/kv` branch also fixes this method, but does a lot more.
This PR just takes the minimum to fix the token auth mehod.